### PR TITLE
Fix portion range validation

### DIFF
--- a/src/requests/setViewPortion.lua
+++ b/src/requests/setViewPortion.lua
@@ -8,6 +8,7 @@ local SetViewPortionRequestType = gt.build(gt.table({
 	portion = gt.number({
 		range = {
 			min = 0,
+			max = math.huge,
 		},
 	}),
 	timestamp = gt.optional(Types.DateTime),


### PR DESCRIPTION
GreenTea's table-form range requires both min and max. Use math.huge for the upper bound.